### PR TITLE
Disabling the feature flag for chrome-service

### DIFF
--- a/cmd/unleash/featureflag.json
+++ b/cmd/unleash/featureflag.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "chrome-service.websockets.enabled",
-    "enabled": true
+    "enabled": false
   },
   {
     "name": "unit-test.true",


### PR DESCRIPTION
The Chrome-service WebSockets are enabled by default, which requires manual effort to switch them in unleash.